### PR TITLE
Pass request by name into methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass `request` by name when calling endpoints from other endpoints ([#44](https://github.com/stac-utils/stac-fastapi-pgstac/pull/44))
+
 ## [2.4.8] - 2023-06-08
 
 ### Changed

--- a/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/core.py
@@ -213,7 +213,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         if settings.use_api_hydrate:
 
             async def _get_base_item(collection_id: str) -> Dict[str, Any]:
-                return await self._get_base_item(collection_id, request)
+                return await self._get_base_item(collection_id, request=request)
 
             base_item_cache = settings.base_item_cache(
                 fetch_base_item=_get_base_item, request=request
@@ -267,7 +267,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             An ItemCollection.
         """
         # If collection does not exist, NotFoundError wil be raised
-        await self.get_collection(collection_id, request)
+        await self.get_collection(collection_id, request=request)
 
         base_args = {
             "collections": [collection_id],
@@ -285,7 +285,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         search_request = self.post_request_model(
             **clean,
         )
-        item_collection = await self._search_base(search_request, request)
+        item_collection = await self._search_base(search_request, request=request)
         links = await ItemCollectionLinks(
             collection_id=collection_id, request=request
         ).get_links(extra_links=item_collection["links"])
@@ -307,12 +307,12 @@ class CoreCrudClient(AsyncBaseCoreClient):
             Item.
         """
         # If collection does not exist, NotFoundError wil be raised
-        await self.get_collection(collection_id, request)
+        await self.get_collection(collection_id, request=request)
 
         search_request = self.post_request_model(
             ids=[item_id], collections=[collection_id], limit=1
         )
-        item_collection = await self._search_base(search_request, request)
+        item_collection = await self._search_base(search_request, request=request)
         if not item_collection["features"]:
             raise NotFoundError(
                 f"Item {item_id} in Collection {collection_id} does not exist."
@@ -333,7 +333,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         Returns:
             ItemCollection containing items which match the search criteria.
         """
-        item_collection = await self._search_base(search_request, request)
+        item_collection = await self._search_base(search_request, request=request)
         return ItemCollection(**item_collection)
 
     async def get_search(

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -8,10 +8,14 @@ from fastapi import Request
 from httpx import AsyncClient
 from pystac import Collection, Extent, Item, SpatialExtent, TemporalExtent
 from stac_fastapi.api.app import StacApi
+from stac_fastapi.api.models import create_post_request_model
+from stac_fastapi.extensions.core import FieldsExtension, TransactionExtension
 from stac_fastapi.types import stac as stac_types
 
 from stac_fastapi.pgstac.core import CoreCrudClient, Settings
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
+from stac_fastapi.pgstac.transactions import TransactionsClient
+from stac_fastapi.pgstac.types.search import PgstacSearch
 
 STAC_CORE_ROUTES = [
     "GET /",
@@ -632,7 +636,7 @@ async def test_sorting_and_paging(app_client, load_test_collection, direction: s
 
 
 @pytest.mark.asyncio
-async def test_wrapped_function() -> None:
+async def test_wrapped_function(load_test_data) -> None:
     # Ensure wrappers, e.g. Planetary Computer's rate limiting, work.
     # https://github.com/gadomski/planetary-computer-apis/blob/2719ccf6ead3e06de0784c39a2918d4d1811368b/pccommon/pccommon/redis.py#L205-L238
 
@@ -661,15 +665,42 @@ async def test_wrapped_function() -> None:
 
     class Client(CoreCrudClient):
         @wrap()
-        async def all_collections(self, **kwargs) -> stac_types.Collections:
-            return await super().all_collections(**kwargs)
+        async def get_collection(
+            self, collection_id: str, request: Request, **kwargs
+        ) -> stac_types.Item:
+            return await super().get_collection(
+                collection_id, request=request, **kwargs
+            )
 
-    api = StacApi(client=Client(), settings=Settings(testing=True))
+    settings = Settings(testing=True)
+    extensions = [
+        TransactionExtension(client=TransactionsClient(), settings=settings),
+        FieldsExtension(),
+    ]
+    post_request_model = create_post_request_model(extensions, base_model=PgstacSearch)
+    api = StacApi(
+        client=Client(post_request_model=post_request_model),
+        settings=settings,
+        extensions=extensions,
+        search_post_request_model=post_request_model,
+    )
     app = api.app
     await connect_to_db(app)
     try:
         async with AsyncClient(app=app) as client:
-            response = await client.get("http://test/collections")
-        assert response.status_code == 200
+            response = await client.post(
+                "http://test/collections",
+                json=load_test_data("test_collection.json"),
+            )
+            assert response.status_code == 200
+            response = await client.post(
+                "http://test/collections/test-collection/items",
+                json=load_test_data("test_item.json"),
+            )
+            assert response.status_code == 200
+            response = await client.get(
+                "http://test/collections/test-collection/items/test-item"
+            )
+            assert response.status_code == 200
     finally:
         await close_db_connection(app)


### PR DESCRIPTION
**Related Issue(s):**

- This makes #22 less breaking.

**Description:**

Some downstreams, e.g. the Planetary Computer, use the `request` as a part of their caching mechanism. #22 has some internal calls to functions where `request` is passed as a positional parameter, which breaks generic caching mechanism, which fetch `request` from `kwargs`. This PR changes to make sure those internal calls pass `request` by name.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
