### PR TITLE
Adding link to collection queryables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `/queryables` link to the collections ([#49](https://github.com/stac-utils/stac-fastapi-pgstac/pull/49))
+
 ## [2.4.9] - 2023-06-21
 
 ### Fixed

--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -208,7 +208,7 @@ class CollectionLinks(CollectionLinksBase):
         """Create the `queryables` link."""
         return dict(
             rel=Relations.queryables.value,
-            type=MimeTypes.schemajson.value,
+            type=MimeTypes.jsonschema.value,
             href=self.resolve(f"collections/{self.collection_id}/queryables"),
         )
 

--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -204,6 +204,14 @@ class CollectionLinks(CollectionLinksBase):
             href=self.resolve(f"collections/{self.collection_id}/items"),
         )
 
+    def link_queryables(self) -> Dict:
+        """Create the `queryables` link."""
+        return dict(
+            rel=Relations.queryables.value,
+            type=MimeTypes.json.value,
+            href=self.resolve(f"collections/{self.collection_id}/queryables"),
+        )
+
 
 @attr.s
 class ItemCollectionLinks(CollectionLinksBase):

--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -11,7 +11,7 @@ from starlette.requests import Request
 
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the classes defined below
-INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root"]
+INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root", Relations.queryables.value]
 
 
 def filter_links(links: List[Dict]) -> List[Dict]:
@@ -208,7 +208,7 @@ class CollectionLinks(CollectionLinksBase):
         """Create the `queryables` link."""
         return dict(
             rel=Relations.queryables.value,
-            type=MimeTypes.json.value,
+            type=MimeTypes.schemajson.value,
             href=self.resolve(f"collections/{self.collection_id}/queryables"),
         )
 


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi/issues/401

**Description:**

Adds a `collection/{collection}/queryables` link to collections.

Depends on https://github.com/stac-utils/stac-pydantic/pull/123

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
