### PR TITLE
Bump pgstac to v0.7.10

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       db_service:
-        image: ghcr.io/stac-utils/pgstac:v0.7.1
+        image: ghcr.io/stac-utils/pgstac:v0.7.10
         env:
           POSTGRES_USER: username
           POSTGRES_PASSWORD: password
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       pgstac:
-        image: ghcr.io/stac-utils/pgstac:v0.7.1
+        image: ghcr.io/stac-utils/pgstac:v0.7.10
         env:
           POSTGRES_USER: username
           POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.7.9
+    image: ghcr.io/stac-utils/pgstac:v0.7.10
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
**Description:**

No code changes, just upping our CI (and `docker-compose.yml`) to use the latest version to make sure week pace. No CHANGELOG required.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
