### PR TITLE
Configurable server_settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Ability to configure the database runtime parameters ([#92](https://github.com/stac-utils/stac-fastapi-pgstac/pull/92))
+
 ## [2.4.11] - 2023-12-01
 
 ### Changed

--- a/stac_fastapi/pgstac/config.py
+++ b/stac_fastapi/pgstac/config.py
@@ -3,6 +3,7 @@
 from typing import List, Type
 from urllib.parse import quote
 
+from pydantic import BaseModel, Extra
 from stac_fastapi.types.config import ApiSettings
 
 from stac_fastapi.pgstac.types.base_item_cache import (
@@ -32,6 +33,13 @@ DEFAULT_INVALID_ID_CHARS = [
 ]
 
 
+class ServerSettings(BaseModel, extra=Extra.allow):
+    """Server runtime parameters."""
+
+    search_path: str = "pgstac,public"
+    application_name: str = "pgstac"
+
+
 class Settings(ApiSettings):
     """Postgres-specific API settings.
 
@@ -58,6 +66,8 @@ class Settings(ApiSettings):
     db_max_queries: int = 50000
     db_max_inactive_conn_lifetime: float = 300
 
+    server_settings: ServerSettings = ServerSettings()
+
     use_api_hydrate: bool = False
     base_item_cache: Type[BaseItemCache] = DefaultBaseItemCache
     invalid_id_chars: List[str] = DEFAULT_INVALID_ID_CHARS
@@ -78,3 +88,8 @@ class Settings(ApiSettings):
     def testing_connection_string(self):
         """Create testing psql connection string."""
         return f"postgresql://{self.postgres_user}:{quote(self.postgres_pass)}@{self.postgres_host_writer}:{self.postgres_port}/pgstactestdb"
+
+    class Config(ApiSettings.Config):
+        """Model config."""
+
+        env_nested_delimiter = "__"

--- a/stac_fastapi/pgstac/db.py
+++ b/stac_fastapi/pgstac/db.py
@@ -132,9 +132,6 @@ class DB:
             max_queries=settings.db_max_queries,
             max_inactive_connection_lifetime=settings.db_max_inactive_conn_lifetime,
             init=con_init,
-            server_settings={
-                "search_path": "pgstac,public",
-                "application_name": "pgstac",
-            },
+            server_settings=settings.server_settings.dict(),
         )
         return pool


### PR DESCRIPTION
In certain scenarios, it would be beneficial to provide a method for setting runtime parameters, such as [statement_timeout](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT). Presently, stac-fastapi-pgstac does not include this functionality. This pull request introduces the capability to configure these parameters using environment variables. Example (test.py):

```python
import asyncio
import asyncpg

from stac_fastapi.types.config import ApiSettings
from pydantic import BaseModel, Extra


class ServerSettings(BaseModel, extra=Extra.allow):
   search_path: str = "pgstac,public"
   application_name: str = "pgstac"


class Settings(ApiSettings):
    postgres_user: str
    postgres_pass: str
    server_settings: ServerSettings = ServerSettings()

    class Config(ApiSettings.Config):
       env_nested_delimiter = "__"


async def main():
    settings = Settings()
    connection_string = f"postgres://{settings.postgres_user}:{settings.postgres_pass}@localhost:5439/postgis"
    pool = await asyncpg.create_pool(
        connection_string,
        server_settings=settings.server_settings.dict()
    )

    async with pool.acquire() as con:
        timeout = await con.fetch("SHOW statement_timeout")
        print(timeout)

    await pool.close()


asyncio.run(main())
```

```
$ POSTGRES_USER=username POSTGRES_PASS=password SERVER_SETTINGS__STATEMENT_TIMEOUT=42 python3 test.py
[<Record statement_timeout='42ms'>]
```

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).