### PR TITLE
refactor tests suite in order to run it locally outside docker

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,38 +5,18 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  LATEST_PY_VERSION: '3.11'
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     timeout-minutes: 20
 
     services:
-      db_service:
-        image: ghcr.io/stac-utils/pgstac:v0.7.10
-        env:
-          POSTGRES_USER: username
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: postgis
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
-          PGUSER: username
-          PGPASSWORD: password
-          PGDATABASE: postgis
-          ALLOW_IP_RANGE: 0.0.0.0/0
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 10s
-          --health-retries 10
-          --log-driver none
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -50,25 +30,26 @@ jobs:
           cache-dependency-path: setup.py
 
       - name: Lint code
-        if: ${{ matrix.python-version == 3.8 }}
+        if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
         run: |
           python -m pip install pre-commit
           pre-commit run --all-files
 
-      - name: Install
+      - name: install lib postgres
         run: |
-          pip install .[dev,server]
+          sudo apt update
+          wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | sudo apt-key add -
+          echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
+          sudo apt update
+          sudo apt-get install --yes libpq-dev postgis postgresql-14-postgis-3
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev,server]
 
       - name: Run test suite
-        run: make test
-        env:
-          ENVIRONMENT: testing
-          POSTGRES_USER: username
-          POSTGRES_PASS: password
-          POSTGRES_DBNAME: postgis
-          POSTGRES_HOST_READER: localhost
-          POSTGRES_HOST_WRITER: localhost
-          POSTGRES_PORT: 5432
+        run:  python -m pytest --cov stac_fastapi.pgstac --cov-report xml --cov-report term-missing
 
   validate:
     runs-on: ubuntu-latest
@@ -90,17 +71,23 @@ jobs:
           --log-driver none
         ports:
           - 5432:5432
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.LATEST_PY_VERSION }}
           cache: pip
           cache-dependency-path: setup.py
+
       - name: Install stac-fastapi and stac-api-validator
-        run: pip install .[server] stac-api-validator==0.4.1
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[server] stac-api-validator==0.4.1
+
       - name: Load data and validate
         run: python -m stac_fastapi.pgstac.app & ./scripts/wait-for-it.sh localhost:8080 && python ./scripts/ingest_joplin.py http://localhost:8080 && ./scripts/validate http://localhost:8080
         env:
@@ -120,15 +107,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.LATEST_PY_VERSION }}
           cache: pip
           cache-dependency-path: setup.py
+
       - name: Install with documentation dependencies
-        run: pip install .[docs,dev,server]
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[docs,dev,server]
+
       - name: Generate API docs
         run: make docs
+
       - name: Build documentation
         run: mkdocs build --strict

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,8 +5,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  LATEST_PY_VERSION: '3.9'
 
 jobs:
   test:
@@ -29,7 +27,7 @@ jobs:
           cache-dependency-path: setup.py
 
       - name: Lint code
-        if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
+        if: ${{ matrix.python-version == 3.8 }}
         run: |
           python -m pip install pre-commit
           pre-commit run --all-files
@@ -73,7 +71,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.LATEST_PY_VERSION }}
+          python-version: "3.10"
           cache: pip
           cache-dependency-path: setup.py
 
@@ -105,7 +103,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.LATEST_PY_VERSION }}
+          python-version: "3.10"
           cache: pip
           cache-dependency-path: setup.py
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -35,12 +35,7 @@ jobs:
           pre-commit run --all-files
 
       - name: install lib postgres
-        run: |
-          sudo apt update
-          wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | sudo apt-key add -
-          echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" | sudo tee /etc/apt/sources.list.d/postgresql.list
-          sudo apt update
-          sudo apt-get install --yes libpq-dev postgis postgresql-14-postgis-3
+        uses: nyurik/action-setup-postgis@v1
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -16,7 +16,6 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     timeout-minutes: 20
 
-    services:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 env:
-  LATEST_PY_VERSION: '3.11'
+  LATEST_PY_VERSION: '3.9'
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,14 @@ repos:
     hooks:
       - id: isort
         language_version: python
+
   - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
         args: ["--safe"]
         language_version: python
+
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
@@ -42,6 +44,7 @@ repos:
   #            -   id: mypy
   #                language_version: python3.8
   #                args: [--no-strict-optional, --ignore-missing-imports]
+
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,18 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        language_version: python3.8
+        language_version: python
   - repo: https://github.com/psf/black
     rev: 22.12.0
     hooks:
       - id: black
         args: ["--safe"]
-        language_version: python3.8
+        language_version: python
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
-        language_version: python3.8
+        language_version: python
         args: [
             # E501 let black handle all line length decisions
             # W503 black conflicts with "line break before operator" rule
@@ -26,7 +26,7 @@ repos:
     rev: v2.1.1
     hooks:
       - id: pydocstyle
-        language_version: python3.8
+        language_version: python
         exclude: ".*(test|scripts).*"
         args:
           [
@@ -46,7 +46,7 @@ repos:
     rev: 6.3.0
     hooks:
       - id: pydocstyle
-        language_version: python3.8
+        language_version: python
         exclude: ".*(test|scripts).*"
         #args: [
         # Don't require docstrings for tests

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -6,18 +6,14 @@ FROM python:${PYTHON_VERSION}-slim as base
 # need the following packages in order to build
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y build-essential git && \
+    apt-get install -y build-essential git libpq-dev postgresql-15-postgis-3  && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-
-FROM base as builder
+RUN useradd -ms /bin/bash newuser
+USER newuser
 
 WORKDIR /app
-
 COPY . /app
 
-RUN python -m pip install -e .[server]
-
-CMD ["uvicorn", "stac_fastapi.pgstac.app:app", "--host", "0.0.0.0", "--port", "8080"]
+RUN python -m pip install -e .[dev,server] --user

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ run = docker-compose run --rm \
 				-e APP_PORT=${APP_PORT} \
 				app
 
+runtests = docker-compose run --rm tests
+
 .PHONY: image
 image:
 	docker-compose build
@@ -28,7 +30,7 @@ docker-shell:
 
 .PHONY: test
 test:
-	$(run) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/tests/ && pytest -vvv --log-cli-level $(LOG_LEVEL)'
+	$(runtests) /bin/bash -c 'export && python -m pytest /app/tests/api/test_api.py --log-cli-level $(LOG_LEVEL)'
 
 .PHONY: run-database
 run-database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
   app:
     container_name: stac-fastapi-pgstac
     image: stac-utils/stac-fastapi-pgstac
-    platform: linux/amd64
     build: .
     environment:
       - APP_HOST=0.0.0.0
@@ -30,6 +29,19 @@ services:
     depends_on:
       - database
     command: bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.pgstac.app"
+
+  tests:
+    container_name: stac-fastapi-pgstac-test
+    image: stac-utils/stac-fastapi-pgstac-test
+    build:
+      context: .
+      dockerfile: Dockerfile.tests
+    environment:
+      - ENVIRONMENT=local
+      - DB_MIN_CONN_SIZE=1
+      - DB_MAX_CONN_SIZE=1
+      - USE_API_HYDRATE=${USE_API_HYDRATE:-false}
+    command: bash -c "python -m pytest -s -vv"
 
   database:
     container_name: stac-db

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ extra_reqs = {
     "dev": [
         "pystac[validation]",
         "pypgstac[psycopg]==0.7.*",
+        "pytest-postgresql",
         "pytest",
         "pytest-cov",
         "pytest-asyncio>=0.17,<0.23.0",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -636,7 +636,7 @@ async def test_sorting_and_paging(app_client, load_test_collection, direction: s
 
 
 @pytest.mark.asyncio
-async def test_wrapped_function(load_test_data) -> None:
+async def test_wrapped_function(load_test_data, database) -> None:
     # Ensure wrappers, e.g. Planetary Computer's rate limiting, work.
     # https://github.com/gadomski/planetary-computer-apis/blob/2719ccf6ead3e06de0784c39a2918d4d1811368b/pccommon/pccommon/redis.py#L205-L238
 
@@ -672,7 +672,16 @@ async def test_wrapped_function(load_test_data) -> None:
                 collection_id, request=request, **kwargs
             )
 
-    settings = Settings(testing=True)
+    settings = Settings(
+        postgres_user=database.user,
+        postgres_pass=database.password,
+        postgres_host_reader=database.host,
+        postgres_host_writer=database.host,
+        postgres_port=database.port,
+        postgres_dbname=database.dbname,
+        testing=True,
+    )
+
     extensions = [
         TransactionExtension(client=TransactionsClient(), settings=settings),
         FieldsExtension(),


### PR DESCRIPTION
This PR propose a refactor of the test suite, moving from local database to pytest fixture. 

This is to ensure we don't touch the local postgres which may run on the user's computer. 

This PR also aims to speed up the CI (avoiding building and user docker image)


FYI:

`make test` is still working for people who want to run tests in Docker but now you can also simply run `python -m pytest -s -vv` (if you have postgres installed locally)