### PR TITLE
update pgstac to 0.8.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+
+- update pgstac version to `0.8.x`
 
 ## [2.5.0] - 2024-04-25
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.7.10
+    image: ghcr.io/stac-utils/pgstac:v0.8.5
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ install_requires = [
     "buildpg",
     "brotli_asgi",
     "pygeofilter>=0.2",
-    "pypgstac==0.7.*",
+    "pypgstac==0.8.*",
 ]
 
 extra_reqs = {
     "dev": [
         "pystac[validation]",
-        "pypgstac[psycopg]==0.7.*",
+        "pypgstac[psycopg]==0.8.*",
         "pytest-postgresql",
         "pytest",
         "pytest-cov",

--- a/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/core.py
@@ -226,6 +226,9 @@ class CoreCrudClient(AsyncBaseCoreClient):
 
             for feature in collection.get("features") or []:
                 base_item = await base_item_cache.get(feature.get("collection"))
+                # Exclude None values
+                base_item = {k: v for k, v in base_item.items() if v is not None}
+
                 feature = hydrate(base_item, feature)
 
                 # Grab ids needed for links that may be removed by the fields extension.

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -476,7 +476,6 @@ async def test_base_queryables(load_test_data, app_client, load_test_collection)
     assert q["type"] == "object"
     assert "properties" in q
     assert "id" in q["properties"]
-    assert "eo:cloud_cover" in q["properties"]
 
 
 @pytest.mark.asyncio
@@ -488,7 +487,6 @@ async def test_collection_queryables(load_test_data, app_client, load_test_colle
     assert q["type"] == "object"
     assert "properties" in q
     assert "id" in q["properties"]
-    assert "eo:cloud_cover" in q["properties"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Right now the CI will fail with `type mismatch` issue from pgstac rust `hydrate` method 

```python
from pypgstac.hydration import hydrate

feature={'id': 'test-item', 'bbox': [149.57574, -34.25796, 152.15194, -32.07915], 'type': 'Feature', 'links': [{'rel': 'self', 'href': 'http://localhost:8081/collections/landsat-8-l1/items/LC82081612020043', 'type': 'application/geo+json'}, {'rel': 'parent', 'href': 'http://localhost:8081/collections/landsat-8-l1', 'type': 'application/json'}, {'rel': 'collection', 'href': 'http://localhost:8081/collections/landsat-8-l1', 'type': 'application/json'}, {'rel': 'root', 'href': 'http://localhost:8081/', 'type': 'application/json'}, {'rel': 'preview', 'href': 'preview.html', 'type': 'application/html'}], 'assets': {'ANG': {'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_ANG.txt', 'type': 'text/plain', 'title': 'Angle Coefficients File', 'description': 'Collection 2 Level-1 Angle Coefficients File (ANG)'}, 'SR_B1': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B1.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Coastal/Aerosol Band (B1)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B1', 'common_name': 'coastal', 'center_wavelength': 0.44, 'full_width_half_max': 0.02}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Coastal/Aerosol Band (B1) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'SR_B2': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B2.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Blue Band (B2)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B2', 'common_name': 'blue', 'center_wavelength': 0.48, 'full_width_half_max': 0.06}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Blue Band (B2) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'SR_B3': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B3.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Green Band (B3)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B3', 'common_name': 'green', 'center_wavelength': 0.56, 'full_width_half_max': 0.06}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Green Band (B3) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'SR_B4': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B4.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Red Band (B4)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B4', 'common_name': 'red', 'center_wavelength': 0.65, 'full_width_half_max': 0.04}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Red Band (B4) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'SR_B5': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B5.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Near Infrared Band 0.8 (B5)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B5', 'common_name': 'nir08', 'center_wavelength': 0.86, 'full_width_half_max': 0.03}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Near Infrared Band 0.8 (B5) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'SR_B6': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B6.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Short-wave Infrared Band 1.6 (B6)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B6', 'common_name': 'swir16', 'center_wavelength': 1.6, 'full_width_half_max': 0.08}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Short-wave Infrared Band 1.6 (B6) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'SR_B7': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_SR_B7.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Short-wave Infrared Band 2.2 (B7)', 'eo:bands': [{'gsd': 30, 'name': 'SR_B7', 'common_name': 'swir22', 'center_wavelength': 2.2, 'full_width_half_max': 0.2}], 'proj:shape': [7731, 7591], 'description': 'Collection 2 Level-2 Short-wave Infrared Band 2.2 (B7) Surface Reflectance', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'ST_QA': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_ST_QA.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Surface Temperature Quality Assessment Band', 'proj:shape': [7731, 7591], 'description': 'Landsat Collection 2 Level-2 Surface Temperature Band Surface Temperature Product', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'ST_B10': {'gsd': 100, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_ST_B10.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Surface Temperature Band (B10)', 'eo:bands': [{'gsd': 100, 'name': 'ST_B10', 'common_name': 'lwir11', 'center_wavelength': 10.9, 'full_width_half_max': 0.8}], 'proj:shape': [7731, 7591], 'description': 'Landsat Collection 2 Level-2 Surface Temperature Band (B10) Surface Temperature Product', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'MTL.txt': {'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_MTL.txt', 'type': 'text/plain', 'title': 'Product Metadata File', 'description': 'Collection 2 Level-1 Product Metadata File (MTL)'}, 'MTL.xml': {'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_MTL.xml', 'type': 'application/xml', 'title': 'Product Metadata File (xml)', 'description': 'Collection 2 Level-1 Product Metadata File (xml)'}, 'ST_DRAD': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_ST_DRAD.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Downwelled Radiance Band', 'eo:bands': [{'gsd': 30, 'name': 'ST_DRAD', 'description': 'downwelled radiance'}], 'proj:shape': [7731, 7591], 'description': 'Landsat Collection 2 Level-2 Downwelled Radiance Band Surface Temperature Product', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'ST_EMIS': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_ST_EMIS.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Emissivity Band', 'eo:bands': [{'gsd': 30, 'name': 'ST_EMIS', 'description': 'emissivity'}], 'proj:shape': [7731, 7591], 'description': 'Landsat Collection 2 Level-2 Emissivity Band Surface Temperature Product', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}, 'ST_EMSD': {'gsd': 30, 'href': 'https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2021/108/066/LC08_L2SP_108066_20210712_20210720_02_T1/LC08_L2SP_108066_20210712_20210720_02_T1_ST_EMSD.TIF', 'type': 'image/tiff; application=geotiff; profile=cloud-optimized', 'title': 'Emissivity Standard Deviation Band', 'eo:bands': [{'gsd': 30, 'name': 'ST_EMSD', 'description': 'emissivity standard deviation'}], 'proj:shape': [7731, 7591], 'description': 'Landsat Collection 2 Level-2 Emissivity Standard Deviation Band Surface Temperature Product', 'proj:transform': [30, 0, 304185, 0, -30, -843585]}}, 'geometry': {'type': 'Polygon', 'coordinates': [[[152.15052873427666, -33.82243006904891], [150.1000346138806, -34.257132625788756], [149.5776607193635, -32.514709769700254], [151.6262528041627, -32.08081674221862], [152.15052873427666, -33.82243006904891]]]}, 'collection': 'test-collection', 'properties': {'gsd': 15, 'width': 2500, 'height': 2500, 'datetime': '2020-02-12T12:30:22Z', 'eo:bands': [{'gsd': 30, 'name': 'B1', 'common_name': 'coastal', 'center_wavelength': 0.44, 'full_width_half_max': 0.02}, {'gsd': 30, 'name': 'B2', 'common_name': 'blue', 'center_wavelength': 0.48, 'full_width_half_max': 0.06}, {'gsd': 30, 'name': 'B3', 'common_name': 'green', 'center_wavelength': 0.56, 'full_width_half_max': 0.06}, {'gsd': 30, 'name': 'B4', 'common_name': 'red', 'center_wavelength': 0.65, 'full_width_half_max': 0.04}, {'gsd': 30, 'name': 'B5', 'common_name': 'nir', 'center_wavelength': 0.86, 'full_width_half_max': 0.03}, {'gsd': 30, 'name': 'B6', 'common_name': 'swir16', 'center_wavelength': 1.6, 'full_width_half_max': 0.08}, {'gsd': 30, 'name': 'B7', 'common_name': 'swir22', 'center_wavelength': 2.2, 'full_width_half_max': 0.2}, {'gsd': 15, 'name': 'B8', 'common_name': 'pan', 'center_wavelength': 0.59, 'full_width_half_max': 0.18}, {'gsd': 30, 'name': 'B9', 'common_name': 'cirrus', 'center_wavelength': 1.37, 'full_width_half_max': 0.02}, {'gsd': 100, 'name': 'B10', 'common_name': 'lwir11', 'center_wavelength': 10.9, 'full_width_half_max': 0.8}, {'gsd': 100, 'name': 'B11', 'common_name': 'lwir12', 'center_wavelength': 12, 'full_width_half_max': 1}], 'platform': 'landsat-8', 'proj:epsg': 32756, 'instrument': 'OLI_TIRS', 'landsat:row': '161', 'landsat:tier': 'RT', 'eo:cloud_cover': 0, 'landsat:column': '208', 'view:off_nadir': 0, 'landsat:revision': '00', 'landsat:scene_id': 'LC82081612020043LGN00', 'view:sun_azimuth': -148.83296771, 'landsat:product_id': 'LC08_L1GT_208161_20200212_20200212_01_RT', 'view:sun_elevation': -37.30791534, 'landsat:processing_level': 'L1GT'}, 'stac_extensions': ['https://stac-extensions.github.io/eo/v1.0.0/schema.json', 'https://stac-extensions.github.io/projection/v1.0.0/schema.json']}

base_item={'type': 'Feature', 'assets': None, 'collection': 'test-collection', 'stac_version': '1.0.0'}

hydrate(base_item, feature)

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: type mismatch
```