### PR TITLE
fix filter extension implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Fix Docker compose file, so example data can be loaded into database (author @zstatmanweil, https://github.com/stac-utils/stac-fastapi-pgstac/pull/142)
 
+- Fix `filter` extension implementation in `CoreCrudClient`
+
 ## [3.0.0] - 2024-08-02
 
 - Enable filter extension for `GET /items` requests and add `Queryables` links in `/collections` and `/collections/{collection_id}` responses ([#89](https://github.com/stac-utils/stac-fastapi-pgstac/pull/89))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     container_name: stac-fastapi-pgstac
@@ -67,8 +66,8 @@ services:
       - ./scripts:/app/scripts
     command: >
       /bin/sh -c "
-        ./scripts/wait-for-it.sh -t 60 app:8082 && 
-        python -m pip install requests && 
+        ./scripts/wait-for-it.sh -t 60 app:8082 &&
+        python -m pip install requests &&
         python /app/scripts/ingest_joplin.py http://app:8082
         "
     depends_on:

--- a/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/core.py
@@ -310,11 +310,14 @@ class CoreCrudClient(AsyncBaseCoreClient):
 
         if self.extension_is_enabled("FilterExtension"):
             filter_lang = kwargs.get("filter_lang", None)
-            filter = kwargs.get("filter", None)
-            if filter is not None and filter_lang == "cql2-text":
-                ast = parse_cql2_text(filter.strip())
-                base_args["filter"] = orjson.loads(to_cql2(ast))
-                base_args["filter-lang"] = "cql2-json"
+            filter_query = kwargs.get("filter", None)
+            if filter_query:
+                if filter_lang == "cql2-text":
+                    filter_query = to_cql2(parse_cql2_text(filter_query))
+                    filter_lang = "cql2-json"
+
+                base_args["filter"] = orjson.loads(filter_query)
+                base_args["filter-lang"] = filter_lang
 
         clean = {}
         for k, v in base_args.items():
@@ -420,9 +423,11 @@ class CoreCrudClient(AsyncBaseCoreClient):
 
         if filter:
             if filter_lang == "cql2-text":
-                ast = parse_cql2_text(filter)
-                base_args["filter"] = orjson.loads(to_cql2(ast))
-                base_args["filter-lang"] = "cql2-json"
+                filter = to_cql2(parse_cql2_text(filter))
+                filter_lang = "cql2-json"
+
+            base_args["filter"] = orjson.loads(filter)
+            base_args["filter-lang"] = filter_lang
 
         if datetime:
             base_args["datetime"] = format_datetime_range(datetime)


### PR DESCRIPTION
closes #148 

This PR fixes the `CoreCrudClient.item_collection` and `CoreCrudClient.get_search` method implementation for the `filter` extension .... and add tests ;-) 

cc @hrodmn