### PR TITLE
handle collection paging differently

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.tests
+    volumes:
+      - .:/app
     environment:
       - ENVIRONMENT=local
       - DB_MIN_CONN_SIZE=1

--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -174,6 +174,60 @@ class PagingLinks(BaseLinks):
 
 
 @attr.s
+class CollectionSearchPagingLinks(BaseLinks):
+    next: Optional[Dict[str, Any]] = attr.ib(kw_only=True, default=None)
+    prev: Optional[Dict[str, Any]] = attr.ib(kw_only=True, default=None)
+
+    def link_next(self) -> Optional[Dict[str, Any]]:
+        """Create link for next page."""
+        if self.next is not None:
+            method = self.request.method
+            if method == "GET":
+                # if offset is equal to default value (0), drop it
+                if self.next["body"].get("offset", -1) == 0:
+                    _ = self.next["body"].pop("offset")
+
+                href = merge_params(self.url, self.next["body"])
+
+                # if next link is equal to this link, skip it
+                if href == self.url:
+                    print(self.request.body())
+                    return None
+
+                link = {
+                    "rel": Relations.next.value,
+                    "type": MimeTypes.geojson.value,
+                    "method": method,
+                    "href": href,
+                }
+                return link
+
+        return None
+
+    def link_prev(self):
+        if self.prev is not None:
+            method = self.request.method
+            if method == "GET":
+                # if offset is equal to default value (0), drop it
+                if self.prev["body"].get("offset", -1) == 0:
+                    _ = self.prev["body"].pop("offset")
+
+                href = merge_params(self.url, self.prev["body"])
+
+                # if prev link is equal to this link, skip it
+                if href == self.url:
+                    return None
+                return {
+                    "rel": Relations.previous.value,
+                    "type": MimeTypes.geojson.value,
+                    "method": method,
+                    "href": href,
+                }
+
+        return None
+
+
+@attr.s
 class CollectionLinksBase(BaseLinks):
     """Create inferred links specific to collections."""
 

--- a/tests/resources/test_collection.py
+++ b/tests/resources/test_collection.py
@@ -313,5 +313,15 @@ async def test_get_collections_search_limit_offset(
         "/collections",
         params={"limit": 1},
     )
-    assert len(resp.json()["collections"]) == 1
-    assert resp.json()["collections"][0]["id"] == load_test_collection["id"]
+    response = resp.json()
+    assert len(response["collections"]) == 1
+    assert response["collections"][0]["id"] == load_test_collection["id"]
+
+    # check next link
+    next_link = [link["href"] for link in response["links"] if link["rel"] == "next"][0]
+    next_url = next_link.replace(str(app_client.base_url), "")
+    next_resp = await app_client.get(next_url)
+    next_response = next_resp.json()
+
+    assert len(next_response["collections"]) == 1
+    assert next_response["collections"][0]["id"] == load_test2_collection.id

--- a/tests/resources/test_collection.py
+++ b/tests/resources/test_collection.py
@@ -314,4 +314,4 @@ async def test_get_collections_search_limit_offset(
         params={"limit": 1},
     )
     assert len(resp.json()["collections"]) == 1
-    assert resp.json()["collections"][0]["id"] == load_test_collection.id
+    assert resp.json()["collections"][0]["id"] == load_test_collection["id"]


### PR DESCRIPTION
Since `pgstac` does not return `prev` or `next` tokens with collection search results, we have to handle the page links differently.
