### PR TITLE
create separate list of collection search extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,7 @@
 
 - Fix Docker compose file, so example data can be loaded into database (author @zstatmanweil, <https://github.com/stac-utils/stac-fastapi-pgstac/pull/142>)
 - Add collection search extension ([#139](https://github.com/stac-utils/stac-fastapi-pgstac/pull/139))
-  - keep item- and collection-search extensions separate ([#158](https://github.com/stac-utils/stac-fastapi-pgstac/pull/158))
-
+- keep `/search` and `/collections` extensions separate ([#158](https://github.com/stac-utils/stac-fastapi-pgstac/pull/158))
 - Fix `filter` extension implementation in `CoreCrudClient`
 
 ## [3.0.0] - 2024-08-02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Fix Docker compose file, so example data can be loaded into database (author @zstatmanweil, <https://github.com/stac-utils/stac-fastapi-pgstac/pull/142>)
 - Add collection search extension ([#139](https://github.com/stac-utils/stac-fastapi-pgstac/pull/139))
+  - keep item- and collection-search extensions separate ([#158](https://github.com/stac-utils/stac-fastapi-pgstac/pull/158))
 
 - Fix `filter` extension implementation in `CoreCrudClient`
 

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -49,6 +49,14 @@ extensions_map = {
     "bulk_transactions": BulkTransactionExtension(client=BulkTransactionsClient()),
 }
 
+# some extensions are supported in combination with the collection search extension
+collection_extensions_map = {
+    "query": QueryExtension(),
+    "sort": SortExtension(),
+    "fields": FieldsExtension(),
+    "filter": FilterExtension(client=FiltersClient()),
+}
+
 enabled_extensions = (
     os.environ["ENABLED_EXTENSIONS"].split(",")
     if "ENABLED_EXTENSIONS" in os.environ
@@ -70,10 +78,17 @@ items_get_request_model = (
 )
 
 collection_search_extension = (
-    CollectionSearchExtension.from_extensions(extensions)
+    CollectionSearchExtension.from_extensions(
+        [
+            extension
+            for key, extension in collection_extensions_map.items()
+            if key in enabled_extensions
+        ]
+    )
     if "collection_search" in enabled_extensions
     else None
 )
+
 collections_get_request_model = (
     collection_search_extension.GET if collection_search_extension else EmptyRequest
 )

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -732,7 +732,9 @@ async def test_wrapped_function(load_test_data, database) -> None:
     get_request_model = create_get_request_model(extensions)
 
     collection_search_extension = CollectionSearchExtension.from_extensions(
-        extensions=extensions
+        extensions=[
+            FieldsExtension(),
+        ]
     )
 
     api = StacApi(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,16 @@ def api_client(request, database):
         FilterExtension(client=FiltersClient()),
         BulkTransactionExtension(client=BulkTransactionsClient()),
     ]
-    collection_search_extension = CollectionSearchExtension.from_extensions(extensions)
+
+    collection_extensions = [
+        QueryExtension(),
+        SortExtension(),
+        FieldsExtension(),
+        FilterExtension(client=FiltersClient()),
+    ]
+    collection_search_extension = CollectionSearchExtension.from_extensions(
+        collection_extensions
+    )
 
     items_get_request_model = create_request_model(
         model_name="ItemCollectionUri",


### PR DESCRIPTION
**Related Issue(s):**

- #155 

**Description:**

Since only a subset of extensions can be combined with the collection search extension we need to keep a separate list.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
