### PR TITLE
Fix next, prev link href

### DIFF
--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -129,8 +129,7 @@ class PagingLinks(BaseLinks):
         if self.next is not None:
             method = self.request.method
             if method == "GET":
-                url = self.resolve(f"collections/{self.collection_id}/items")
-                href = merge_params(url, {"token": f"next:{self.next}"})
+                href = merge_params(self.base_url, {"token": f"next:{self.next}"})
                 link = {
                     "rel": Relations.next.value,
                     "type": MimeTypes.geojson.value,
@@ -155,8 +154,7 @@ class PagingLinks(BaseLinks):
         if self.prev is not None:
             method = self.request.method
             if method == "GET":
-                url = self.resolve(f"collections/{self.collection_id}/items")
-                href = merge_params(url, {"token": f"prev:{self.prev}"})
+                href = merge_params(self.base_url, {"token": f"prev:{self.prev}"})
                 return {
                     "rel": Relations.previous.value,
                     "type": MimeTypes.geojson.value,

--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -129,7 +129,8 @@ class PagingLinks(BaseLinks):
         if self.next is not None:
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": f"next:{self.next}"})
+                url = self.resolve(f"collections/{self.collection_id}/items")
+                href = merge_params(url, {"token": f"next:{self.next}"})
                 link = {
                     "rel": Relations.next.value,
                     "type": MimeTypes.geojson.value,
@@ -154,7 +155,8 @@ class PagingLinks(BaseLinks):
         if self.prev is not None:
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": f"prev:{self.prev}"})
+                url = self.resolve(f"collections/{self.collection_id}/items")
+                href = merge_params(url, {"token": f"prev:{self.prev}"})
                 return {
                     "rel": Relations.previous.value,
                     "type": MimeTypes.geojson.value,


### PR DESCRIPTION
## Description

When path prefixes are used in FastAPI, the `next` and `prev` collection items links don't include the path prefix. See https://github.com/NASA-IMPACT/veda-backend/issues/444 for a specific example. This PR uses `self.resolve` similar to other links (which include the path prefix).