### PR TITLE
add CORS configuration via env variables

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,9 +1,13 @@
 name: stac-fastapi
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - maint-3.0.x
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - maint-3.0.x
 
 
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - maint-3.0.x
     tags:
       - "*"
   workflow_dispatch:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [3.0.1] - 2024-11-14
+
+- Enable runtime `CORS` configuration using environment variables (`CORS_ORIGIN="https://...,https://..."`, `CORS_METHODS="PUT,OPTIONS"`)
+
 ## [3.0.0] - 2024-08-02
 
 - Enable filter extension for `GET /items` requests and add `Queryables` links in `/collections` and `/collections/{collection_id}` responses ([#89](https://github.com/stac-utils/stac-fastapi-pgstac/pull/89))

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -7,8 +7,10 @@ If the variable is not set, enables all extensions.
 
 import os
 
+from brotli_asgi import BrotliMiddleware
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.api.app import StacApi
+from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
 from stac_fastapi.api.models import (
     ItemCollectionUri,
     create_get_request_model,
@@ -23,6 +25,7 @@ from stac_fastapi.extensions.core import (
     TransactionExtension,
 )
 from stac_fastapi.extensions.third_party import BulkTransactionExtension
+from starlette.middleware import Middleware
 
 from stac_fastapi.pgstac.config import Settings
 from stac_fastapi.pgstac.core import CoreCrudClient
@@ -75,6 +78,15 @@ api = StacApi(
     items_get_request_model=items_get_request_model,
     search_get_request_model=get_request_model,
     search_post_request_model=post_request_model,
+    middlewares=[
+        Middleware(BrotliMiddleware),
+        Middleware(ProxyHeaderMiddleware),
+        Middleware(
+            CORSMiddleware,
+            allow_origins=settings.cors_origins,
+            allow_methods=settings.cors_methods,
+        ),
+    ],
 )
 app = api.app
 

--- a/stac_fastapi/pgstac/config.py
+++ b/stac_fastapi/pgstac/config.py
@@ -3,7 +3,7 @@
 from typing import List, Type
 from urllib.parse import quote_plus as quote
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from pydantic_settings import SettingsConfigDict
 from stac_fastapi.types.config import ApiSettings
 
@@ -75,7 +75,20 @@ class Settings(ApiSettings):
     base_item_cache: Type[BaseItemCache] = DefaultBaseItemCache
     invalid_id_chars: List[str] = DEFAULT_INVALID_ID_CHARS
 
+    cors_origins: str = "*"
+    cors_methods: str = "GET,POST,OPTIONS"
+
     testing: bool = False
+
+    @field_validator("cors_origins")
+    def parse_cors_origin(cls, v):
+        """Parse CORS origins."""
+        return [origin.strip() for origin in v.split(",")]
+
+    @field_validator("cors_methods")
+    def parse_cors_methods(cls, v):
+        """Parse CORS methods."""
+        return [method.strip() for method in v.split(",")]
 
     @property
     def reader_connection_string(self):


### PR DESCRIPTION
closes https://github.com/stac-utils/stac-fastapi-pgstac/issues/50

I changed my mind because it fact for users enabling the transaction extension, adding `PUT` methods will be mandatory, so if we let the extensions list to be configured by env variable we need to enable the CORS configuration as well 
