### PR TITLE
use enum values and fix fields pydantic validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- use Relation's `value` for `POST` prev/next links
+- return `JSONResponse` directly from `/items` endpoint when `fields` parameter is pass and avoid Pydantic validation
+
+### Changed
+
+- avoid re-use of internal `CoreCrudClient.post_search` in `CoreCrudClient.get_search` method to allow customization
+
 ## [4.0.1] - 2025-02-06
 
 ### Added

--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -140,8 +140,8 @@ class PagingLinks(BaseLinks):
 
             if method == "POST":
                 return {
-                    "rel": Relations.next,
-                    "type": MimeTypes.geojson,
+                    "rel": Relations.next.value,
+                    "type": MimeTypes.geojson.value,
                     "method": method,
                     "href": f"{self.request.url}",
                     "body": {**self.request.postbody, "token": f"next:{self.next}"},
@@ -164,8 +164,8 @@ class PagingLinks(BaseLinks):
 
             if method == "POST":
                 return {
-                    "rel": Relations.previous,
-                    "type": MimeTypes.geojson,
+                    "rel": Relations.previous.value,
+                    "type": MimeTypes.geojson.value,
                     "method": method,
                     "href": f"{self.request.url}",
                     "body": {**self.request.postbody, "token": f"prev:{self.prev}"},

--- a/tests/resources/test_item.py
+++ b/tests/resources/test_item.py
@@ -1073,6 +1073,13 @@ async def test_field_extension_get(app_client, load_test_data, load_test_collect
     assert resp.status_code == 201
 
     params = {"fields": "+properties.proj:epsg,+properties.gsd,+collection"}
+    resp = await app_client.get(
+        f"/collections/{test_item['collection']}/items", params=params
+    )
+    feat_properties = resp.json()["features"][0]["properties"]
+    assert not set(feat_properties) - {"proj:epsg", "gsd", "datetime"}
+
+    params = {"fields": "+properties.proj:epsg,+properties.gsd,+collection"}
     resp = await app_client.get("/search", params=params)
     feat_properties = resp.json()["features"][0]["properties"]
     assert not set(feat_properties) - {"proj:epsg", "gsd", "datetime"}


### PR DESCRIPTION
This PR does: 
- fix validation issue when fields extension is enable for `/items` endpoint (return JSONResponse to avoid pydantic validation)
- use Relation enum value for POST Links (to match links for GET) 
- avoid re-using `post_search` method to ease customization (mostly because we don't want to have to deal with a possible JSONReponse from the `post_search` method 