### PR TITLE
add missing q param for item search and collection-items search

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- add missing `q` parameters for free-text search extensions on `/search` 
+  and `/collections/{collection_id}/items` endpoints
+- add `str` type for `q` parameter when free-text advanced search extension is employed
 - rename `POSTGRES_HOST_READER` to `PGHOST` in config **breaking change**
 - rename `POSTGRES_USER` to `PGUSER` in config **breaking change**
 - rename `POSTGRES_PASS` to `PGPASSWORD` in config **breaking change**

--- a/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/core.py
@@ -54,7 +54,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         sortby: Optional[str] = None,
         filter_expr: Optional[str] = None,
         filter_lang: Optional[str] = None,
-        q: Optional[List[str]] = None,
+        q: Optional[List[str] | str] = None,
         **kwargs,
     ) -> Collections:
         """Cross catalog search (GET).
@@ -359,6 +359,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         filter_expr: Optional[str] = None,
         filter_lang: Optional[str] = None,
         token: Optional[str] = None,
+        q: Optional[List[str] | str] = None,
         **kwargs,
     ) -> ItemCollection:
         """Get all items from a specific collection.
@@ -391,6 +392,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             filter_lang=filter_lang,
             fields=fields,
             sortby=sortby,
+            q=q,
         )
 
         try:
@@ -489,6 +491,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         filter_expr: Optional[str] = None,
         filter_lang: Optional[str] = None,
         token: Optional[str] = None,
+        q: Optional[List[str] | str] = None,
         **kwargs,
     ) -> ItemCollection:
         """Cross catalog search (GET).
@@ -516,6 +519,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             sortby=sortby,
             filter_query=filter_expr,
             filter_lang=filter_lang,
+            q=q,
         )
 
         try:
@@ -550,7 +554,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         sortby: Optional[str] = None,
         filter_query: Optional[str] = None,
         filter_lang: Optional[str] = None,
-        q: Optional[List[str]] = None,
+        q: Optional[List[str] | str] = None,
     ) -> Dict[str, Any]:
         """Clean up search arguments to match format expected by pgstac"""
         if filter_query:
@@ -595,7 +599,9 @@ class CoreCrudClient(AsyncBaseCoreClient):
 
             base_args["fields"] = {"include": includes, "exclude": excludes}
 
-        if q:
+        # free-text search basic list[str] vs advanced str
+        # it is up to advanced to form the string properly
+        if isinstance(q, list):
             base_args["q"] = " OR ".join(q)
 
         # Remove None values from dict


### PR DESCRIPTION

**Related Issue(s):**

- #263
- https://github.com/stac-utils/stac-fastapi/pull/849
- https://github.com/stac-api-extensions/freetext-search/pull/13

**Description:**

Whether the `q` basic/advanced extension get moved/split/else, they currently define `q` parameter on other endpoints that are not handled by the API (only `/collections?q=...` was handled. 

This adds the `q` parameter to `/search` and `/collections/{collection_id}/items` as well (`GET`).

For `POST`, a similar PR adding `q` is needed in https://github.com/stac-utils/stac-pydantic to adjust the model.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
