### PR TITLE
feat: Add PREFIX_PATH config

### DIFF
--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -9,7 +9,7 @@ import os
 from contextlib import asynccontextmanager
 
 from brotli_asgi import BrotliMiddleware
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
 from stac_fastapi.api.models import (
@@ -171,6 +171,7 @@ api = StacApi(
         description=settings.stac_fastapi_description,
         lifespan=lifespan,
     ),
+    router=APIRouter(prefix=settings.prefix_path),
     settings=settings,
     extensions=application_extensions,
     client=CoreCrudClient(pgstac_search_model=post_request_model),

--- a/stac_fastapi/pgstac/config.py
+++ b/stac_fastapi/pgstac/config.py
@@ -159,11 +159,13 @@ class Settings(ApiSettings):
     """API settings.
 
     Attributes:
+        prefix_path: An optional path prefix for the underyling FastAPI router.
         use_api_hydrate: perform hydration of stac items within stac-fastapi.
         invalid_id_chars: list of characters that are not allowed in item or collection ids.
 
     """
 
+    prefix_path: str = ""
     use_api_hydrate: bool = False
     invalid_id_chars: List[str] = DEFAULT_INVALID_ID_CHARS
     base_item_cache: Type[BaseItemCache] = DefaultBaseItemCache


### PR DESCRIPTION
**Related Issue(s):**

- #262 

**Description:**
This adds a new config `PREFIX_PATH` that is used when instantiating a StacApi by passing the router kwarg: router=APIRouter(prefix=settings.prefix_path)

The new setting is documented and the default value is an empty string.

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
