### PR TITLE
feat: add CORS credentials to settings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,5 +1,4 @@
 
-
 ### Application Extension
 
 The default `stac-fastapi-pgstac` application comes will **all** extensions enabled (except transaction). Users can use `ENABLED_EXTENSIONS` environment variable to limit the supported extensions.
@@ -15,7 +14,6 @@ Available values for `ENABLED_EXTENSIONS`:
 - `collection_search`
 
 Example: `ENABLED_EXTENSIONS="pagination,sort"`
-
 
 Since `6.0.0`, the transaction extension is not enabled by default. To add the transaction endpoints, users can set `ENABLE_TRANSACTIONS_EXTENSIONS=TRUE/YES/1`.
 
@@ -60,5 +58,6 @@ In version `6.0.0` we've renamed the PG configuration variable to match the offi
 - `ROOT_PATH`: set application root-path (when using proxy)
 - `CORS_ORIGINS`: A list of origins that should be permitted to make cross-origin requests. Defaults to `*`
 - `CORS_METHODS`: A list of HTTP methods that should be allowed for cross-origin requests. Defaults to `"GET,POST,OPTIONS"`
+- `CORS_CREDENTIALS`: Set to `true` to enable credentials via CORS requests. Note that you'll need to set `CORS_ORIGINS` to something other than `*`, because credentials are [disallowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS/Errors/CORSNotSupportingCredentials) for wildcard CORS origins.
 - `USE_API_HYDRATE`: perform hydration of stac items within stac-fastapi
 - `INVALID_ID_CHARS`: list of characters that are not allowed in item or collection ids (used in Transaction endpoints)

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -186,6 +186,7 @@ api = StacApi(
             CORSMiddleware,
             allow_origins=settings.cors_origins,
             allow_methods=settings.cors_methods,
+            allow_credentials=settings.cors_credentials,
         ),
     ],
     health_check=health_check,

--- a/stac_fastapi/pgstac/config.py
+++ b/stac_fastapi/pgstac/config.py
@@ -170,6 +170,7 @@ class Settings(ApiSettings):
 
     cors_origins: str = "*"
     cors_methods: str = "GET,POST,OPTIONS"
+    cors_credentials: bool = False
 
     testing: bool = False
 


### PR DESCRIPTION
If we're going to put [stac-auth-proxy](https://github.com/developmentseed/stac-auth-proxy) in front of **stac-fastapi-pgstac**, we'll want to allow deployments to enable [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials) easily.

cc @alukach 