### PR TITLE
ignore 'rel:items' entries when generating links

### DIFF
--- a/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/models/links.py
@@ -11,7 +11,7 @@ from starlette.requests import Request
 
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the classes defined below
-INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root"]
+INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root", "items"]
 
 
 def filter_links(links: List[Dict]) -> List[Dict]:


### PR DESCRIPTION
**Related Issue(s):**

- fixes #285
- fixes https://github.com/crim-ca/stac-populator/issues/109

**Description:**

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
