### PR TITLE
Add non-root user for Docker container.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Docker container runs as non-root user
+
 ## [6.1.0] - 2025-11-03
 
 ### Changed
@@ -15,7 +19,7 @@
 
 - lower bounds for `hydraters` requirements
 - `EXCLUDE_HYDRATE_MARKERS=TRUE/FALSE` (defaults to `TRUE`) to exclude `𒍟※` markers returned by PgSTAC
-- python `3.13` and `3.14` support 
+- python `3.13` and `3.14` support
 
 ### removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,14 @@ RUN python -m pip install -U pip
 WORKDIR /app
 
 COPY stac_fastapi/ stac_fastapi/
-COPY pyproject.toml pyproject.toml 
+COPY pyproject.toml pyproject.toml
 COPY README.md README.md
 
 RUN python -m pip install .[server]
 RUN rm -rf stac_fastapi .toml README.md
+
+RUN groupadd -g 1000 user && \
+    useradd -u 1000 -g user -s /bin/bash -m user
+USER user
 
 CMD ["uvicorn", "stac_fastapi.pgstac.app:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
**Related Issue(s):**

https://github.com/EOEPCA/resource-discovery/issues/163

**Description:**

Runs containers as non-root user `user` with id abd gid `1000`.

**PR Checklist:**

- ~pre-commit` hooks pass locally~
- ~Tests pass (run `make test`)~
- ~Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)~
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
