### PR TITLE
add warning note about pagination extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PgSTAC stores all collection and item records as jsonb fields exactly as they co
 ## Usage
 
 PgSTAC is an external project and may be used by multiple front ends.
-For Stac FastAPI development, a Docker image (which is pulled as part of the docker-compose) is available via the [Github container registry](https://github.com/stac-utils/pgstac/pkgs/container/pgstac/81689794?tag=latest).
+For STAC FastAPI development, a Docker image (which is pulled as part of the docker-compose) is available via the [Github container registry](https://github.com/stac-utils/pgstac/pkgs/container/pgstac/81689794?tag=latest).
 The PgSTAC version required by **stac-fastapi-pgstac** is found in the [setup](http://github.com/stac-utils/stac-fastapi-pgstac/blob/main/setup.py) file.
 
 ### Sorting
@@ -63,9 +63,9 @@ pypgstac migrate
 
 Install the packages in editable mode:
 
-We recommand using [`uv`](https://docs.astral.sh/uv) as project manager for development.
+We recommend using [`uv`](https://docs.astral.sh/uv) as project manager for development.
 
-See https://docs.astral.sh/uv/getting-started/installation/ for installation 
+See https://docs.astral.sh/uv/getting-started/installation/ for installation
 
 ```shell
 uv sync --dev
@@ -77,7 +77,7 @@ To run the tests:
 uv run pytest
 ```
 
-**NOTE:** In order for the above commands to work, you need a number of postgres/postgis system packages to be installed. If running the tests directly on your machine doesn't work, another way is to spin up a test container and run the tests in that container. You need [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed. 
+**NOTE:** In order for the above commands to work, you need a number of postgres/postgis system packages to be installed. If running the tests directly on your machine doesn't work, another way is to spin up a test container and run the tests in that container. You need [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed.
 
 To run the tests in the test container:
 ```shell

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -10,7 +10,7 @@ Available values for `ENABLED_EXTENSIONS`:
 - `fields`
 - `filter`
 - `free_text` (only for collection-search)
-- `pagination`
+- `pagination` (see [Pagination](#pagination) details)
 - `collection_search`
 
 Example: `ENABLED_EXTENSIONS="pagination,sort"`
@@ -48,6 +48,19 @@ In version `6.0.0` we've renamed the PG configuration variable to match the offi
 
 - `ENABLE_RESPONSE_MODELS`: use pydantic models to validate endpoint responses. Defaults to `False`
 - `ENABLE_DIRECT_RESPONSE`: by-pass the default FastAPI serialization by wrapping the endpoint responses into `starlette.Response` classes. Defaults to `False`
+
+### Pagination
+
+The `limit` query parameter (or its default) will trigger pagination of Collection or Items depending on API request context when more entries exist than requested.
+Each following page will then be accessible from the corresponding `next` link in the response containing the appropriate pagination `token` or `offset`.
+
+This PgSTAC backend only implements [`token`-based pagination for Items](https://github.com/stac-utils/pgstac/blob/df08f9bd66ddb057133bfcc8d7a6228ac791e49e/src/pgstac/sql/004_search.sql#L950)
+and [`offset`-based pagination for Collections](https://github.com/stac-utils/pgstac/blob/df08f9bd66ddb057133bfcc8d7a6228ac791e49e/src/pgstac/sql/004a_collectionsearch.sql#L49).
+Therefore, your [`stac-fastapi` pagination extension configuration](https://github.com/stac-utils/stac-fastapi/tree/main/stac_fastapi/extensions/stac_fastapi/extensions/core/pagination)
+MUST apply the corresponding implementations adequately when using this backend.
+Any other variant will cause search to report incorrect `next` links and will not yield expected Collections or Items responses.
+See [`stac-fastapi-pgstac/stac_fastapi/pgstac/app.py`](https://github.com/stac-utils/stac-fastapi-pgstac/blob/main/stac_fastapi/pgstac/app.py)
+for a concrete example of valid configuration.
 
 ### Misc
 


### PR DESCRIPTION
**Related Issue(s):**

- fixes #334

**Description:**

Add the pagination extension details as discussed in the issue.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
