### PR TITLE
Fix changelog, missing v6.2.2 link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -578,7 +578,8 @@ As a part of this release, this repository was extracted from the main
 
 - First PyPi release!
 
-[Unreleased]: <https://github.com/stac-utils/stac-fastapi-pgstac/compare/6.2.1..main>
+[Unreleased]: <https://github.com/stac-utils/stac-fastapi-pgstac/compare/6.2.2..main>
+[6.2.2]: <https://github.com/stac-utils/stac-fastapi-pgstac/compare/6.2.1..6.2.2>
 [6.2.1]: <https://github.com/stac-utils/stac-fastapi-pgstac/compare/6.2.0..6.2.1>
 [6.2.0]: <https://github.com/stac-utils/stac-fastapi-pgstac/compare/6.1.5..6.2.0>
 [6.1.5]: <https://github.com/stac-utils/stac-fastapi-pgstac/compare/6.1.4..6.1.5>


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

- Fix changelog, missing v6.2.2 link

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
