### PR TITLE
Update to catalogs extension v0.4.0. add hide alternate parents env var, add missing "related" links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - implement `neq` query operator ([#364](https://github.com/stac-utils/stac-fastapi-pgstac/pull/364))
 - add api test for `neq` query operator ([#364](https://github.com/stac-utils/stac-fastapi-pgstac/pull/364))
 - Multi-Tenant Catalogs Extension: Integrated optional `stac-fastapi-catalogs-extension` to support native DAG (Directed Acyclic Graph) traversal of Catalogs and Collections. Enabled via `ENABLE_CATALOGS_EXTENSION` environment variable ([#366](https://github.com/stac-utils/stac-fastapi-pgstac/pull/366))
-- Added `HIDE_ALTERNATE_PARENTS` environment variable (default `False`) to suppress `rel="related"` and `rel="duplicate"` links for alternate parents in poly-hierarchy. Useful for multi-tenant deployments to prevent information leakage about other tenants. When enabled, only the contextual `rel="parent"` link is advertised. Requires `ENABLE_CATALOGS_ROUTE=true`. ([#387](https://github.com/stac-utils/stac-fastapi-pgstac/pull/387))
+- Added `HIDE_ALTERNATE_PARENTS` environment variable (default `False`) to suppress `rel="related"` and `rel="duplicate"` links for alternate parents in poly-hierarchy. Useful for multi-tenant deployments to prevent information leakage about other tenants. When enabled, only the contextual `rel="parent"` link is advertised. Requires `ENABLE_CATALOGS_EXTENSION=true`. ([#387](https://github.com/stac-utils/stac-fastapi-pgstac/pull/387))
 - Added `rel="duplicate"` links for scoped collection endpoints (`/catalogs/{catalogId}/collections/{collectionId}`) to expose alternative scoped paths where collections can be accessed through other parent catalogs in poly-hierarchy. ([#387](https://github.com/stac-utils/stac-fastapi-pgstac/pull/387))
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,10 +14,16 @@
 - implement `neq` query operator ([#364](https://github.com/stac-utils/stac-fastapi-pgstac/pull/364))
 - add api test for `neq` query operator ([#364](https://github.com/stac-utils/stac-fastapi-pgstac/pull/364))
 - Multi-Tenant Catalogs Extension: Integrated optional `stac-fastapi-catalogs-extension` to support native DAG (Directed Acyclic Graph) traversal of Catalogs and Collections. Enabled via `ENABLE_CATALOGS_EXTENSION` environment variable ([#366](https://github.com/stac-utils/stac-fastapi-pgstac/pull/366))
+- Added `HIDE_ALTERNATE_PARENTS` environment variable (default `False`) to suppress `rel="related"` and `rel="duplicate"` links for alternate parents in poly-hierarchy. Useful for multi-tenant deployments to prevent information leakage about other tenants. When enabled, only the contextual `rel="parent"` link is advertised. Requires `ENABLE_CATALOGS_ROUTE=true`.
+- Added `rel="duplicate"` links for scoped collection endpoints (`/catalogs/{catalogId}/collections/{collectionId}`) to expose alternative scoped paths where collections can be accessed through other parent catalogs in poly-hierarchy.
 
 ### Fixed
 
 - preprocess `fields` to give the `include` set precendence over the `exclude` set ([#370](https://github.com/stac-utils/stac-fastapi-pgstac/pull/370))
+
+### Updated
+
+- Update stac-fastapi-catalogs-extension to v0.4.0 
 
 ## [6.2.2] - 2026-01-09
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,8 +14,9 @@
 - implement `neq` query operator ([#364](https://github.com/stac-utils/stac-fastapi-pgstac/pull/364))
 - add api test for `neq` query operator ([#364](https://github.com/stac-utils/stac-fastapi-pgstac/pull/364))
 - Multi-Tenant Catalogs Extension: Integrated optional `stac-fastapi-catalogs-extension` to support native DAG (Directed Acyclic Graph) traversal of Catalogs and Collections. Enabled via `ENABLE_CATALOGS_EXTENSION` environment variable ([#366](https://github.com/stac-utils/stac-fastapi-pgstac/pull/366))
-- Added `HIDE_ALTERNATE_PARENTS` environment variable (default `False`) to suppress `rel="related"` and `rel="duplicate"` links for alternate parents in poly-hierarchy. Useful for multi-tenant deployments to prevent information leakage about other tenants. When enabled, only the contextual `rel="parent"` link is advertised. Requires `ENABLE_CATALOGS_ROUTE=true`.
-- Added `rel="duplicate"` links for scoped collection endpoints (`/catalogs/{catalogId}/collections/{collectionId}`) to expose alternative scoped paths where collections can be accessed through other parent catalogs in poly-hierarchy.
+- Added `HIDE_ALTERNATE_PARENTS` environment variable (default `False`) to suppress `rel="related"` and `rel="duplicate"` links for alternate parents in poly-hierarchy. Useful for multi-tenant deployments to prevent information leakage about other tenants. When enabled, only the contextual `rel="parent"` link is advertised. Requires `ENABLE_CATALOGS_ROUTE=true`. ([#387](https://github.com/stac-utils/stac-fastapi-pgstac/pull/387))
+- Added `rel="duplicate"` links for scoped collection endpoints (`/catalogs/{catalogId}/collections/{collectionId}`) to expose alternative scoped paths where collections can be accessed through other parent catalogs in poly-hierarchy. ([#387](https://github.com/stac-utils/stac-fastapi-pgstac/pull/387))
+
 
 ### Fixed
 
@@ -23,7 +24,7 @@
 
 ### Updated
 
-- Update stac-fastapi-catalogs-extension to v0.4.0 
+- Update stac-fastapi-catalogs-extension to v0.4.0 ([#387](https://github.com/stac-utils/stac-fastapi-pgstac/pull/387))
 
 ## [6.2.2] - 2026-01-09
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,18 @@ To enable this extension, install the `stac-fastapi-catalogs-extension` package 
 
 For write operations (creating, updating, and deleting catalogs, and linking/unlinking collections and catalogs), also set `ENABLE_TRANSACTIONS_EXTENSIONS=TRUE`.
 
-For more details, see the [settings documentation](./docs/src/settings.md#multi-tenant-catalogs-extension).
+#### Poly-Hierarchy Links
+
+When a catalog or collection has multiple parents, the API exposes the catalog hierarchy through STAC link relations:
+
+- `rel="parent"`: Points to the contextual parent (the catalog through which the resource was accessed)
+- `rel="related"`: Links to alternative parents in the poly-hierarchy (for catalogs and scoped collections)
+- `rel="duplicate"`: Links to alternative scoped paths where a collection can be accessed (e.g., `/catalogs/{parentId}/collections/{collectionId}`)
+- `rel="canonical"`: Points to the global collection endpoint for scoped collections
+
+To prevent information leakage about other tenants in multi-tenant deployments, set `HIDE_ALTERNATE_PARENTS=TRUE` to suppress `rel="related"` and `rel="duplicate"` links. When enabled, only the contextual `rel="parent"` link is advertised.
+
+**Note:** The link relation names for poly-hierarchy navigation are subject to change as the OGC and STAC communities continue to standardize on terminology. These names may be updated in future releases to align with emerging standards.
 
 ### Migrations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
         "pypgstac>=0.9,<0.10",
         "requests",
         "shapely",
-        "stac-fastapi-catalogs-extension==0.3.0",
+        "stac-fastapi-catalogs-extension==0.4.0",
         "httpx",
         "psycopg[pool,binary]==3.2.*",
         "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ server  = [
     "uvicorn[standard]==0.38.0"
 ]
 catalogs = [
-    "stac-fastapi-catalogs-extension==0.3.0",
+    "stac-fastapi-catalogs-extension==0.4.0",
 ]
 
 [dependency-groups]

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -252,8 +252,6 @@ api = StacApi(
 )
 app = api.app
 
-app.state.catalogs_hide_alternate_parents = settings.hide_alternate_parents
-
 
 def run():
     """Run app from command line using uvicorn if available."""

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -253,6 +253,8 @@ api = StacApi(
 )
 app = api.app
 
+app.state.catalogs_hide_alternate_parents = settings.hide_alternate_parents
+
 
 def run():
     """Run app from command line using uvicorn if available."""

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -199,7 +199,6 @@ if settings.enable_catalogs_extension:
             catalogs_transaction_extension = CatalogsTransactionExtension(
                 client=catalogs_client,
                 settings={"enable_response_models": settings.enable_response_models},
-                hide_alternate_parents=settings.hide_alternate_parents,
             )
             application_extensions.append(catalogs_transaction_extension)
             logger.info("CatalogsTransactionExtension enabled successfully.")

--- a/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/app.py
@@ -174,6 +174,7 @@ if "collection_search" in enabled_extensions:
 
 # Optional catalogs extension
 logger.info("ENABLE_CATALOGS_EXTENSION is set to %s", settings.enable_catalogs_extension)
+logger.info("HIDE_ALTERNATE_PARENTS is set to %s", settings.hide_alternate_parents)
 
 if settings.enable_catalogs_extension:
     if CatalogsExtension is None:
@@ -188,6 +189,7 @@ if settings.enable_catalogs_extension:
         catalogs_extension = CatalogsExtension(
             client=catalogs_client,
             settings={"enable_response_models": settings.enable_response_models},
+            hide_alternate_parents=settings.hide_alternate_parents,
         )
         application_extensions.append(catalogs_extension)
         logger.info("CatalogsExtension (read-only) enabled successfully.")
@@ -197,6 +199,7 @@ if settings.enable_catalogs_extension:
             catalogs_transaction_extension = CatalogsTransactionExtension(
                 client=catalogs_client,
                 settings={"enable_response_models": settings.enable_response_models},
+                hide_alternate_parents=settings.hide_alternate_parents,
             )
             application_extensions.append(catalogs_transaction_extension)
             logger.info("CatalogsTransactionExtension enabled successfully.")

--- a/stac_fastapi/pgstac/config.py
+++ b/stac_fastapi/pgstac/config.py
@@ -202,6 +202,7 @@ class Settings(ApiSettings):
     enabled_extensions: str = ""
     enable_transactions_extensions: bool = False
     enable_catalogs_extension: bool = False
+    hide_alternate_parents: bool = False
     validate_extensions: bool = False
     """
     Validate `stac_extensions` schemas against submitted data when creating or updated STAC objects.

--- a/stac_fastapi/pgstac/extensions/catalogs/catalogs_client.py
+++ b/stac_fastapi/pgstac/extensions/catalogs/catalogs_client.py
@@ -22,6 +22,7 @@ from stac_fastapi.pgstac.extensions.catalogs.catalogs_database_logic import (
 from stac_fastapi.pgstac.extensions.catalogs.catalogs_links import (
     CatalogLinks,
     ChildLinks,
+    ScopedCollectionLinks,
     SubCatalogLinks,
 )
 from stac_fastapi.pgstac.models.links import (
@@ -372,10 +373,28 @@ class CatalogsClient(AsyncBaseCatalogsClient):
             collection_id, catalog_id, base_url, self_href
         )
 
-        # Add related links for poly-hierarchy
-        CatalogsClient._add_related_links(
-            collection, parent_ids, catalog_id, collection_id, base_url
+        # Add poly-hierarchy links using ScopedCollectionLinks
+        scoped_links = ScopedCollectionLinks(
+            collection_id=collection_id,
+            catalog_id=catalog_id,
+            parent_ids=parent_ids,
+            request=request,
         )
+
+        # Add related links if present
+        related = scoped_links.link_related()
+        if related:
+            collection["links"].extend(related)
+
+        # Add canonical link if present
+        canonical = scoped_links.link_canonical()
+        if canonical:
+            collection["links"].append(canonical)
+
+        # Add duplicate links if present
+        duplicate = scoped_links.link_duplicate()
+        if duplicate:
+            collection["links"].extend(duplicate)
 
         # Remove internal metadata
         collection.pop("parent_ids", None)
@@ -393,11 +412,6 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 "rel": "self",
                 "type": "application/json",
                 "href": self_href,
-            },
-            {
-                "rel": "canonical",
-                "type": "application/json",
-                "href": base_url + f"/collections/{collection_id}",
             },
             {
                 "rel": "items",
@@ -428,33 +442,6 @@ class CatalogsClient(AsyncBaseCatalogsClient):
                 "href": base_url + f"/collections/{collection_id}/sortables",
             },
         ]
-
-    @staticmethod
-    def _add_related_links(
-        collection: dict,
-        parent_ids: list[str],
-        catalog_id: str,
-        collection_id: str,
-        base_url: str,
-    ) -> None:
-        """Add related links for poly-hierarchy."""
-        if parent_ids and len(parent_ids) > 1:
-            for parent_id in parent_ids:
-                if parent_id != catalog_id:  # Don't link to self
-                    related_href = (
-                        base_url + f"/catalogs/{parent_id}/collections/{collection_id}"
-                    )
-                    collection["links"].append(
-                        {
-                            "rel": "related",
-                            "type": "application/json",
-                            "href": related_href,
-                            "title": f"Collection in {parent_id}",
-                        }
-                    )
-
-        # Remove internal metadata
-        collection.pop("parent_ids", None)
 
     @staticmethod
     def _extract_limit_and_token(

--- a/stac_fastapi/pgstac/extensions/catalogs/catalogs_links.py
+++ b/stac_fastapi/pgstac/extensions/catalogs/catalogs_links.py
@@ -390,10 +390,10 @@ class ScopedCollectionLinks(BaseLinks):
     parent_ids: list[str] = attr.ib(kw_only=True, factory=list)
 
     def link_related(self) -> list[dict] | None:
-        """Create related links for alternative parents (poly-hierarchy).
+        """Create related links for alternative parent catalogs (poly-hierarchy).
 
         Returns:
-            A list of link dicts with rel='related' for other parents, or None.
+            A list of link dicts with rel='related' for other parent catalogs, or None.
         """
         if not self.parent_ids or len(self.parent_ids) <= 1:
             return None
@@ -412,10 +412,8 @@ class ScopedCollectionLinks(BaseLinks):
                     {
                         "rel": "related",
                         "type": MimeTypes.json.value,
-                        "href": self.resolve(
-                            f"catalogs/{parent_id}/collections/{self.collection_id}"
-                        ),
-                        "title": f"Collection in {parent_id}",
+                        "href": self.resolve(f"catalogs/{parent_id}"),
+                        "title": parent_id,
                     }
                 )
         return related_links if related_links else None
@@ -436,10 +434,10 @@ class ScopedCollectionLinks(BaseLinks):
         }
 
     def link_duplicate(self) -> list[dict] | None:
-        """Create duplicate links for alternative scoped paths (poly-hierarchy).
+        """Create duplicate links for alternative scoped collection paths (poly-hierarchy).
 
         Returns:
-            A list of link dicts with rel='duplicate' for other scoped paths, or None.
+            A list of link dicts with rel='duplicate' for other scoped collection paths, or None.
         """
         if not self.parent_ids or len(self.parent_ids) <= 1:
             return None
@@ -451,7 +449,6 @@ class ScopedCollectionLinks(BaseLinks):
         if hide_alternate_parents:
             return None
 
-        # Create duplicate links for each alternative parent's scoped path
         duplicate_links = []
         for parent_id in self.parent_ids:
             if parent_id != self.catalog_id:  # Don't link to self

--- a/stac_fastapi/pgstac/extensions/catalogs/catalogs_links.py
+++ b/stac_fastapi/pgstac/extensions/catalogs/catalogs_links.py
@@ -200,6 +200,13 @@ class ChildLinks(BaseLinks):
         if not self.parent_ids or len(self.parent_ids) <= 1:
             return None
 
+        # Check if hide_alternate_parents is enabled
+        hide_alternate_parents = getattr(
+            self.request.app.state, "catalogs_hide_alternate_parents", False
+        )
+        if hide_alternate_parents:
+            return None
+
         related_links = []
         for parent_id in self.parent_ids:
             if parent_id != self.catalog_id:  # Don't link to self
@@ -284,6 +291,13 @@ class SubCatalogLinks(BaseLinks):
         if not self.parent_ids or len(self.parent_ids) <= 1:
             return None
 
+        # Check if hide_alternate_parents is enabled
+        hide_alternate_parents = getattr(
+            self.request.app.state, "catalogs_hide_alternate_parents", False
+        )
+        if hide_alternate_parents:
+            return None
+
         related_links = []
         for parent_id in self.parent_ids:
             if parent_id != self.catalog_id:  # Don't link to self
@@ -356,3 +370,98 @@ class CatalogSubcatalogsLinks(BaseLinks):
                 ),
             }
         return None
+
+
+@attr.s
+class ScopedCollectionLinks(BaseLinks):
+    """Create inferred links for a collection in a scoped catalog context.
+
+    Generates related, duplicate, and canonical links for a collection accessed
+    through a specific catalog endpoint (/catalogs/{catalogId}/collections/{collectionId}).
+
+    Attributes:
+        collection_id: The ID of the collection.
+        catalog_id: The ID of the parent catalog (current context).
+        parent_ids: List of parent catalog IDs (for poly-hierarchy).
+    """
+
+    collection_id: str = attr.ib()
+    catalog_id: str = attr.ib()
+    parent_ids: list[str] = attr.ib(kw_only=True, factory=list)
+
+    def link_related(self) -> list[dict] | None:
+        """Create related links for alternative parents (poly-hierarchy).
+
+        Returns:
+            A list of link dicts with rel='related' for other parents, or None.
+        """
+        if not self.parent_ids or len(self.parent_ids) <= 1:
+            return None
+
+        # Check if hide_alternate_parents is enabled
+        hide_alternate_parents = getattr(
+            self.request.app.state, "catalogs_hide_alternate_parents", False
+        )
+        if hide_alternate_parents:
+            return None
+
+        related_links = []
+        for parent_id in self.parent_ids:
+            if parent_id != self.catalog_id:  # Don't link to self
+                related_links.append(
+                    {
+                        "rel": "related",
+                        "type": MimeTypes.json.value,
+                        "href": self.resolve(
+                            f"catalogs/{parent_id}/collections/{self.collection_id}"
+                        ),
+                        "title": f"Collection in {parent_id}",
+                    }
+                )
+        return related_links if related_links else None
+
+    def link_canonical(self) -> dict | None:
+        """Create canonical link pointing to global collection endpoint.
+
+        Returns:
+            A link dict with rel='canonical' pointing to /collections/{collectionId}, or None.
+        """
+        if not self.parent_ids:
+            return None
+
+        return {
+            "rel": "canonical",
+            "type": MimeTypes.json.value,
+            "href": self.resolve(f"collections/{self.collection_id}"),
+        }
+
+    def link_duplicate(self) -> list[dict] | None:
+        """Create duplicate links for alternative scoped paths (poly-hierarchy).
+
+        Returns:
+            A list of link dicts with rel='duplicate' for other scoped paths, or None.
+        """
+        if not self.parent_ids or len(self.parent_ids) <= 1:
+            return None
+
+        # Check if hide_alternate_parents is enabled
+        hide_alternate_parents = getattr(
+            self.request.app.state, "catalogs_hide_alternate_parents", False
+        )
+        if hide_alternate_parents:
+            return None
+
+        # Create duplicate links for each alternative parent's scoped path
+        duplicate_links = []
+        for parent_id in self.parent_ids:
+            if parent_id != self.catalog_id:  # Don't link to self
+                duplicate_links.append(
+                    {
+                        "rel": "duplicate",
+                        "type": MimeTypes.json.value,
+                        "href": self.resolve(
+                            f"catalogs/{parent_id}/collections/{self.collection_id}"
+                        ),
+                    }
+                )
+        return duplicate_links if duplicate_links else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,7 +260,6 @@ async def app(api_client, pgstac):
         add_write_connection_pool=True,
     )
 
-    # Initialize catalogs extension state
     app.state.catalogs_hide_alternate_parents = False
 
     yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,6 +260,9 @@ async def app(api_client, pgstac):
         add_write_connection_pool=True,
     )
 
+    # Initialize catalogs extension state
+    app.state.catalogs_hide_alternate_parents = False
+
     yield app
 
     await close_db_connection(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,8 +260,6 @@ async def app(api_client, pgstac):
         add_write_connection_pool=True,
     )
 
-    app.state.catalogs_hide_alternate_parents = False
-
     yield app
 
     await close_db_connection(app)

--- a/tests/extensions/test_catalogs.py
+++ b/tests/extensions/test_catalogs.py
@@ -1916,6 +1916,46 @@ async def test_hide_alternate_parents_suppresses_related_links_on_scoped_collect
 
 
 @pytest.mark.asyncio
+async def test_hide_alternate_parents_false_shows_related_and_duplicate_links(
+    app_client,
+):
+    """Test that hide_alternate_parents=False (default) shows both related and duplicate links on scoped collections."""
+    # Create two parent catalogs
+    parent_catalog_1 = await create_catalog(app_client, "parent-catalog-false-1")
+    parent_id_1 = parent_catalog_1["id"]
+
+    parent_catalog_2 = await create_catalog(app_client, "parent-catalog-false-2")
+    parent_id_2 = parent_catalog_2["id"]
+
+    # Create a collection linked to both catalogs
+    collection_id = "test-collection-false"
+    coll_resp = await create_catalog_collection(
+        app_client, parent_id_1, collection_id, description="Test collection"
+    )
+    assert coll_resp["id"] == collection_id
+
+    link_resp = await app_client.post(
+        f"/catalogs/{parent_id_2}/collections", json={"id": collection_id}
+    )
+    assert link_resp.status_code == 200
+
+    # Check scoped collection endpoint (where related and duplicate links are added)
+    resp = await app_client.get(f"/catalogs/{parent_id_1}/collections/{collection_id}")
+    assert resp.status_code == 200
+
+    links = resp.json().get("links", [])
+    related_links = [link for link in links if link.get("rel") == "related"]
+    assert (
+        len(related_links) >= 1
+    ), "Expected related links when hide_alternate_parents=False, got none"
+
+    duplicate_links = [link for link in links if link.get("rel") == "duplicate"]
+    assert (
+        len(duplicate_links) >= 1
+    ), "Expected duplicate links when hide_alternate_parents=False, got none"
+
+
+@pytest.mark.asyncio
 async def test_hide_alternate_parents_suppresses_related_links_on_catalog(
     app, app_client, monkeypatch
 ):
@@ -1952,41 +1992,3 @@ async def test_hide_alternate_parents_suppresses_related_links_on_catalog(
     # Parent link should still be present
     parent_links = [link for link in links if link.get("rel") == "parent"]
     assert len(parent_links) == 1, "Should still have exactly 1 parent link"
-
-
-@pytest.mark.asyncio
-async def test_hide_alternate_parents_false_shows_related_links(app_client):
-    """Test that hide_alternate_parents=False (default) still shows rel=related links."""
-    # Create two parent catalogs
-    parent_catalog_1 = await create_catalog(app_client, "parent-catalog-false-1")
-    parent_id_1 = parent_catalog_1["id"]
-
-    parent_catalog_2 = await create_catalog(app_client, "parent-catalog-false-2")
-    parent_id_2 = parent_catalog_2["id"]
-
-    # Create a collection linked to both catalogs
-    collection_id = "test-collection-false"
-    coll_resp = await create_catalog_collection(
-        app_client, parent_id_1, collection_id, description="Test collection"
-    )
-    assert coll_resp["id"] == collection_id
-
-    link_resp = await app_client.post(
-        f"/catalogs/{parent_id_2}/collections", json={"id": collection_id}
-    )
-    assert link_resp.status_code == 200
-
-    # Check scoped collection endpoint (where related links are added)
-    resp = await app_client.get(f"/catalogs/{parent_id_1}/collections/{collection_id}")
-    assert resp.status_code == 200
-
-    links = resp.json().get("links", [])
-    related_links = [link for link in links if link.get("rel") == "related"]
-    assert (
-        len(related_links) >= 1
-    ), "Expected related links when hide_alternate_parents=False, got none"
-
-    duplicate_links = [link for link in links if link.get("rel") == "duplicate"]
-    assert (
-        len(duplicate_links) >= 1
-    ), "Expected duplicate links when hide_alternate_parents=False, got none"

--- a/tests/extensions/test_catalogs.py
+++ b/tests/extensions/test_catalogs.py
@@ -1815,3 +1815,178 @@ async def test_create_catalog_collection_parent_not_found(app_client):
     )
     assert resp.status_code == 404, resp.text
     assert "not found" in resp.text.lower()
+
+
+# ============================================================================
+# hide_alternate_parents Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_hide_alternate_parents_suppresses_related_links_on_global_collection(
+    app, app_client, monkeypatch
+):
+    """Test that hide_alternate_parents=True suppresses rel=related links on global /collections."""
+    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True)
+
+    # Create two parent catalogs
+    parent_catalog_1 = await create_catalog(app_client, "parent-catalog-1")
+    parent_id_1 = parent_catalog_1["id"]
+
+    parent_catalog_2 = await create_catalog(app_client, "parent-catalog-2")
+    parent_id_2 = parent_catalog_2["id"]
+
+    # Create a collection linked to both catalogs
+    collection_id = "test-collection-global"
+    coll_resp = await create_catalog_collection(
+        app_client, parent_id_1, collection_id, description="Test collection"
+    )
+    assert coll_resp["id"] == collection_id
+
+    link_resp = await app_client.post(
+        f"/catalogs/{parent_id_2}/collections", json={"id": collection_id}
+    )
+    assert link_resp.status_code == 200
+
+    resp = await app_client.get(f"/collections/{collection_id}")
+    assert resp.status_code == 200
+
+    links = resp.json().get("links", [])
+    related_links = [link for link in links if link.get("rel") == "related"]
+    assert (
+        len(related_links) == 0
+    ), f"Expected no related links with hide_alternate_parents=True, got: {related_links}"
+
+    duplicate_links = [link for link in links if link.get("rel") == "duplicate"]
+    assert (
+        len(duplicate_links) == 0
+    ), f"Expected no duplicate links with hide_alternate_parents=True, got: {duplicate_links}"
+
+    # Parent link should still point to root
+    parent_links = [link for link in links if link.get("rel") == "parent"]
+    assert len(parent_links) == 1, "Should still have exactly 1 parent link"
+
+
+@pytest.mark.asyncio
+async def test_hide_alternate_parents_suppresses_related_links_on_scoped_collection(
+    app, app_client, monkeypatch
+):
+    """Test that hide_alternate_parents=True suppresses rel=related on scoped /catalogs/{id}/collections/{id}."""
+    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True)
+
+    # Create two parent catalogs
+    parent_catalog_1 = await create_catalog(app_client, "parent-catalog-scoped-1")
+    parent_id_1 = parent_catalog_1["id"]
+
+    parent_catalog_2 = await create_catalog(app_client, "parent-catalog-scoped-2")
+    parent_id_2 = parent_catalog_2["id"]
+
+    # Create a collection linked to both catalogs
+    collection_id = "test-collection-scoped"
+    coll_resp = await create_catalog_collection(
+        app_client, parent_id_1, collection_id, description="Test collection"
+    )
+    assert coll_resp["id"] == collection_id
+
+    link_resp = await app_client.post(
+        f"/catalogs/{parent_id_2}/collections", json={"id": collection_id}
+    )
+    assert link_resp.status_code == 200
+
+    resp = await app_client.get(f"/catalogs/{parent_id_1}/collections/{collection_id}")
+    assert resp.status_code == 200
+
+    links = resp.json().get("links", [])
+    related_links = [link for link in links if link.get("rel") == "related"]
+    assert (
+        len(related_links) == 0
+    ), f"Expected no related links with hide_alternate_parents=True, got: {related_links}"
+
+    duplicate_links = [link for link in links if link.get("rel") == "duplicate"]
+    assert (
+        len(duplicate_links) == 0
+    ), f"Expected no duplicate links with hide_alternate_parents=True, got: {duplicate_links}"
+
+    # Parent link should still point to the contextual catalog
+    parent_links = [link for link in links if link.get("rel") == "parent"]
+    assert len(parent_links) == 1, "Should still have exactly 1 parent link"
+    assert (
+        f"/catalogs/{parent_id_1}" in parent_links[0]["href"]
+    ), "Parent link should point to contextual catalog, not alternate"
+
+
+@pytest.mark.asyncio
+async def test_hide_alternate_parents_suppresses_related_links_on_catalog(
+    app, app_client, monkeypatch
+):
+    """Test that hide_alternate_parents=True suppresses rel=related on catalog with multiple parents."""
+    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True)
+
+    # Create two parent catalogs
+    parent_catalog_1 = await create_catalog(app_client, "parent-catalog-cat-1")
+    parent_id_1 = parent_catalog_1["id"]
+
+    parent_catalog_2 = await create_catalog(app_client, "parent-catalog-cat-2")
+    parent_id_2 = parent_catalog_2["id"]
+
+    # Create a child catalog under parent_1
+    child_id = "child-catalog"
+    child_resp = await create_sub_catalog(app_client, parent_id_1, child_id)
+    assert child_resp["id"] == child_id
+
+    # Also link the child to parent_2 (poly-hierarchy)
+    link_resp = await app_client.post(
+        f"/catalogs/{parent_id_2}/catalogs", json={"id": child_id}
+    )
+    assert link_resp.status_code in [200, 201]
+
+    resp = await app_client.get(f"/catalogs/{child_id}")
+    assert resp.status_code == 200
+
+    links = resp.json().get("links", [])
+    related_links = [link for link in links if link.get("rel") == "related"]
+    assert (
+        len(related_links) == 0
+    ), f"Expected no related links with hide_alternate_parents=True, got: {related_links}"
+
+    # Parent link should still be present
+    parent_links = [link for link in links if link.get("rel") == "parent"]
+    assert len(parent_links) == 1, "Should still have exactly 1 parent link"
+
+
+@pytest.mark.asyncio
+async def test_hide_alternate_parents_false_shows_related_links(app_client):
+    """Test that hide_alternate_parents=False (default) still shows rel=related links."""
+    # Create two parent catalogs
+    parent_catalog_1 = await create_catalog(app_client, "parent-catalog-false-1")
+    parent_id_1 = parent_catalog_1["id"]
+
+    parent_catalog_2 = await create_catalog(app_client, "parent-catalog-false-2")
+    parent_id_2 = parent_catalog_2["id"]
+
+    # Create a collection linked to both catalogs
+    collection_id = "test-collection-false"
+    coll_resp = await create_catalog_collection(
+        app_client, parent_id_1, collection_id, description="Test collection"
+    )
+    assert coll_resp["id"] == collection_id
+
+    link_resp = await app_client.post(
+        f"/catalogs/{parent_id_2}/collections", json={"id": collection_id}
+    )
+    assert link_resp.status_code == 200
+
+    # Check scoped collection endpoint (where related links are added)
+    resp = await app_client.get(f"/catalogs/{parent_id_1}/collections/{collection_id}")
+    assert resp.status_code == 200
+
+    links = resp.json().get("links", [])
+    related_links = [link for link in links if link.get("rel") == "related"]
+    assert (
+        len(related_links) >= 1
+    ), "Expected related links when hide_alternate_parents=False, got none"
+
+    duplicate_links = [link for link in links if link.get("rel") == "duplicate"]
+    assert (
+        len(duplicate_links) >= 1
+    ), "Expected duplicate links when hide_alternate_parents=False, got none"

--- a/tests/extensions/test_catalogs.py
+++ b/tests/extensions/test_catalogs.py
@@ -1827,7 +1827,7 @@ async def test_hide_alternate_parents_suppresses_related_links_on_global_collect
     app, app_client, monkeypatch
 ):
     """Test that hide_alternate_parents=True suppresses rel=related links on global /collections."""
-    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True)
+    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True, raising=False)
 
     # Create two parent catalogs
     parent_catalog_1 = await create_catalog(app_client, "parent-catalog-1")
@@ -1872,7 +1872,7 @@ async def test_hide_alternate_parents_suppresses_related_links_on_scoped_collect
     app, app_client, monkeypatch
 ):
     """Test that hide_alternate_parents=True suppresses rel=related on scoped /catalogs/{id}/collections/{id}."""
-    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True)
+    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True, raising=False)
 
     # Create two parent catalogs
     parent_catalog_1 = await create_catalog(app_client, "parent-catalog-scoped-1")
@@ -1920,7 +1920,7 @@ async def test_hide_alternate_parents_suppresses_related_links_on_catalog(
     app, app_client, monkeypatch
 ):
     """Test that hide_alternate_parents=True suppresses rel=related on catalog with multiple parents."""
-    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True)
+    monkeypatch.setattr(app.state, "catalogs_hide_alternate_parents", True, raising=False)
 
     # Create two parent catalogs
     parent_catalog_1 = await create_catalog(app_client, "parent-catalog-cat-1")


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/StacLabs/stac-fastapi-catalogs-extension/issues/9
- https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/768

**Description:**

- Added `HIDE_ALTERNATE_PARENTS` environment variable (default `False`) to suppress `rel="related"` and `rel="duplicate"` links for alternate parents in poly-hierarchy. Useful for multi-tenant deployments to prevent information leakage about other tenants. When enabled, only the contextual `rel="parent"` link is advertised. Requires `ENABLE_CATALOGS_EXTENSION=true`.
- Added `rel="duplicate"` links for scoped collection endpoints (`/catalogs/{catalogId}/collections/{collectionId}`) to expose alternative scoped paths where collections can be accessed through other parent catalogs in poly-hierarchy.
- Update stac-fastapi-catalogs-extension to v0.4.0.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
