### PR TITLE
fix: update sort conformance class to v1.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fix multi-platform Docker builds by adding QEMU emulation and correcting workflow_dispatch trigger ([#337](https://github.com/stac-utils/stac-fastapi-pgstac/pull/337))
-- Fix conformance classes to use v1.1.0 instead of v1.0.0 ([#402](https://github.com/stac-utils/stac-fastapi-pgstac/pull/402))
+- Fix sort conformance class test to expect v1.1.0 instead of v1.0.0 ([#402](https://github.com/stac-utils/stac-fastapi-pgstac/pull/402))
 
 ## [6.3.1] - 2026-06-24
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Fix multi-platform Docker builds by adding QEMU emulation and correcting workflow_dispatch trigger ([#337](https://github.com/stac-utils/stac-fastapi-pgstac/pull/337))
-- Fix conformance classes to use v1.1.0 instead of v1.0.0 ([#397](https://github.com/stac-utils/stac-fastapi-pgstac/pull/397))
+- Fix conformance classes to use v1.1.0 instead of v1.0.0 ([#402](https://github.com/stac-utils/stac-fastapi-pgstac/pull/402))
 
 ## [6.3.1] - 2026-06-24
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix multi-platform Docker builds by adding QEMU emulation and correcting workflow_dispatch trigger ([#337](https://github.com/stac-utils/stac-fastapi-pgstac/pull/337))
+- Fix conformance classes to use v1.1.0 instead of v1.0.0 ([#397](https://github.com/stac-utils/stac-fastapi-pgstac/pull/397))
 
 ## [6.3.1] - 2026-06-24
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1082,7 +1082,7 @@ async def test_default_app(default_client, default_app, load_test_data):
     assert "https://api.stacspec.org/v1.0.0-rc.1/collection-search" in conf
     assert "https://api.stacspec.org/v1.0.0/collections" in conf
     assert "https://api.stacspec.org/v1.0.0/ogcapi-features#query" in conf
-    assert "https://api.stacspec.org/v1.0.0/ogcapi-features#sort" in conf
+    assert "https://api.stacspec.org/v1.1.0/ogcapi-features#sort" in conf
 
 
 async def test_app_transactions_validate_extension(


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

stac-fastapi 6.4.0 updated the sort extension from v1.0.0 to v1.1.0. This pr fixes the tests to expect the right conformance class. This has been tested with stac-fastapi v6.4.1.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
